### PR TITLE
Image name should contain creator's name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ This example uses `/tmp/postgresql` to store the Postgresql data, but you can mo
 
 ```
 $ mkdir -p /tmp/postgresql
-$ sudo docker run -p 5432 -v /tmp/postgresql:/data postgresql
+$ sudo docker run -d -p 5432 -v /tmp/postgresql:/data paintedfox/postgresql
 ```


### PR DESCRIPTION
Docker asks for the complete image name: paintedfox/postgresql

Also, I have included the "-d" attribute, because I see is the common use.
