### PR TITLE
Add ability to create a database on run via `-e DB` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,16 @@ environment variables.  This lets you discover the username and password of the
 superuser from within a linked container or from the output of `docker inspect
 postgresql`.
 
+If you set DB=database_name, when the container runs it will create a new
+database with the USER having full ownership of it.
+
 ``` shell
 $ mkdir -p /tmp/postgresql
 $ docker run -d -name="postgresql" \
              -p 127.0.0.1:5432:5432 \
              -v /tmp/postgresql:/data \
              -e USER="super" \
+             -e DB="database_name" \
              -e PASS="$(pwgen -s -1 16)" \
              paintedfox/postgresql
 ```

--- a/scripts/first_run.sh
+++ b/scripts/first_run.sh
@@ -6,6 +6,7 @@ pre_start_action() {
   echo "POSTGRES_USER=$USER"
   echo "POSTGRES_PASS=$PASS"
   echo "POSTGRES_DATA_DIR=$DATA_DIR"
+  if [ $(env | grep DB) ]; then echo "POSTGRES_DATABASE=$DB";fi
 
   # test if DATA_DIR has content
   if [[ ! "$(ls -A $DATA_DIR)" ]]; then
@@ -30,6 +31,15 @@ post_start_action() {
     ALTER ROLE $USER WITH SUPERUSER;
     ALTER ROLE $USER WITH LOGIN;
 EOF"
+
+  # create database if requested
+  if [ $(env | grep DB) ]; then
+    echo "Creating database: $DB"
+    su postgres -c "psql -q <<-EOF
+    CREATE DATABASE $DB WITH OWNER=$USER;
+    GRANT ALL ON DATABASE $DB TO $USER
+EOF"
+  fi
 
   rm /firstrun
 }


### PR DESCRIPTION
By passing `-e DB=database_name` upon run, database will automatically be created
