### PR TITLE
Changed base image and added postgresql-contrib package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Postgresql (http://www.postgresql.org/)
 
-FROM ubuntu:precise
+FROM phusion/baseimage
 MAINTAINER Ryan Seto <ryanseto@yak.net>
 
 RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
@@ -14,7 +14,7 @@ ENV LC_ALL     en_US.UTF-8
 # Install the latest postgresql
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes postgresql-9.3 && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes postgresql-9.3 postgresql-client-9.3 postgresql-contrib-9.3 && \
     /etc/init.d/postgresql stop
 
 # Install other tools.


### PR DESCRIPTION
- Changed base image to phusion/baseimage (https://github.com/phusion/baseimage-docker)
- Added postgresql-contrib-9.3 to enable extensions such as hstore and uuid
