### PR TITLE
Force UTF-8 encoding for databases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ ENV LANG       en_US.UTF-8
 ENV LC_ALL     en_US.UTF-8
 ENV DEBIAN_FRONTEND     noninteractive
 
+# Get the Postgresql keys
+RUN apt-get install -y wget
+RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+
 # Install the latest postgresql
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,16 +10,16 @@ RUN apt-get update
 RUN locale-gen en_US.UTF-8
 ENV LANG       en_US.UTF-8
 ENV LC_ALL     en_US.UTF-8
+ENV DEBIAN_FRONTEND     noninteractive
 
 # Install the latest postgresql
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes postgresql-9.3 postgresql-client-9.3 postgresql-contrib-9.3 && \
+    apt-get install -y --force-yes postgresql-9.3 postgresql-client-9.3 postgresql-contrib-9.3 && \
     /etc/init.d/postgresql stop
 
 # Install other tools.
-RUN DEBIAN_FRONTEND=noninteractive && \
-    apt-get install -y pwgen inotify-tools
+RUN apt-get install -y pwgen inotify-tools
 
 # Decouple our data from our container.
 VOLUME ["/data"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,12 @@ RUN apt-get install -y pwgen inotify-tools
 # Decouple our data from our container.
 VOLUME ["/data"]
 
+RUN echo "Dropping current cluster"
+RUN pg_dropcluster --stop 9.3 main
+
+RUN echo "Creating new cluster with UTF8 encoding"
+RUN pg_createcluster --locale=en_US.UTF8 --start 9.3 main
+
 # Cofigure the database to use our data dir.
 RUN sed -i -e"s/data_directory =.*$/data_directory = '\/data'/" /etc/postgresql/9.3/main/postgresql.conf
 # Allow connections from anywhere.

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,20 +10,19 @@ RUN apt-get update
 RUN locale-gen en_US.UTF-8
 ENV LANG       en_US.UTF-8
 ENV LC_ALL     en_US.UTF-8
-ENV DEBIAN_FRONTEND     noninteractive
 
 # Get the Postgresql keys
-RUN apt-get install -y wget
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 
 # Install the latest postgresql
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     apt-get update && \
-    apt-get install -y --force-yes postgresql-9.3 postgresql-client-9.3 postgresql-contrib-9.3 && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes postgresql-9.3 postgresql-client-9.3 postgresql-contrib-9.3 && \
     /etc/init.d/postgresql stop
 
 # Install other tools.
-RUN apt-get install -y pwgen inotify-tools
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y pwgen inotify-tools
 
 # Decouple our data from our container.
 VOLUME ["/data"]

--- a/scripts/first_run.sh
+++ b/scripts/first_run.sh
@@ -40,7 +40,7 @@ EOF"; do
   if [ $(env | grep DB) ]; then
     echo "Creating database: $DB"
     su postgres -c "psql -q <<-EOF
-    CREATE DATABASE $DB WITH OWNER=$USER;
+    CREATE DATABASE $DB WITH OWNER=$USER ENCODING='UTF8';
     GRANT ALL ON DATABASE $DB TO $USER
 EOF"
   fi


### PR DESCRIPTION
On a light virtual machine installation of Ubuntu the original docker image always resulted in a SQL_ASCII encoding of databases. The changes in this pull request force a UTF8 encoding for template0 and the newly created database for this docker image.
