### PR TITLE
Fix syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y pwgen inotify-tools
 # Decouple our data from our container.
 VOLUME ["/data"]
 
-RUN echo "Dropping current cluster" &&
+RUN echo "Dropping current cluster" && \
     pg_dropcluster --stop 9.3 main
 
-RUN echo "Creating new cluster with UTF8 encoding" &&
+RUN echo "Creating new cluster with UTF8 encoding" && \
     pg_createcluster --locale=en_US.UTF8 --start 9.3 main
 
 # Cofigure the database to use our data dir.


### PR DESCRIPTION
Fixes

``` bash
Step 12 : RUN echo "Dropping current cluster" &&
 ---> Running in 22e7d796c4ca
/bin/sh: 1: Syntax error: end of file unexpected
2014/05/08 18:13:59 The command [/bin/sh -c echo "Dropping current cluster" &&] returned a non-zero code: 2
make: *** [build] Error 1
```
