### PR TITLE
Multiple db's: $DB and $EXTENSIONS are escaped

### DIFF
--- a/scripts/first_run.sh
+++ b/scripts/first_run.sh
@@ -33,7 +33,7 @@ post_start_action() {
 EOF
 
   # create database if requested
-  if [ ! -z $DB ]; then
+  if [ ! -z "$DB" ]; then
     for db in $DB; do
       echo "Creating database: $db"
       setuser postgres psql -q <<-EOF
@@ -43,7 +43,7 @@ EOF
     done
   fi
 
-  if [[ ! -z $EXTENSIONS && ! -z $DB ]]; then
+  if [[ ! -z "$EXTENSIONS" && ! -z "$DB" ]]; then
     for extension in $EXTENSIONS; do
       for db in $DB; do
         echo "Installing extension for $db: $extension"


### PR DESCRIPTION
In order to make "for" loop works with multiple values in $DB and $EXTENSIONS
we have to escape these variables.

Example: DB="db1 db2" EXTENSIONS="ex1 ext2"

Without escaping it will cause shell error.
