### PR TITLE
Retain ownership and permissions when copying postgres data at first run

### DIFF
--- a/scripts/first_run.sh
+++ b/scripts/first_run.sh
@@ -13,7 +13,7 @@ pre_start_action() {
       echo "Initializing PostgreSQL at $DATA_DIR"
 
       # Copy the data that we generated within the container to the empty DATA_DIR.
-      cp -R /var/lib/postgresql/9.3/main/* $DATA_DIR
+      cp -aR /var/lib/postgresql/9.3/main/* $DATA_DIR
   fi
 
   # Ensure postgres owns the DATA_DIR


### PR DESCRIPTION
I ran into a problem where Postgres complained about incorrect permissions.
This fixed it, and generally is a good idea here IMHO.
