### PR TITLE
Releases/v9.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,10 @@ RUN touch /firstrun
 RUN mkdir /etc/service/postgresql
 RUN ln -s /scripts/start.sh /etc/service/postgresql/run
 
+# Correct the Error: could not open temporary statistics file "/var/run/postgresql/9.3-main.pg_stat_tmp/global.tmp": No such file or directory
+RUN mkdir -p /var/run/postgresql/9.3-main.pg_stat_tmp
+RUN chown postgres.postgres /var/run/postgresql/9.3-main.pg_stat_tmp -R
+
 # Expose our data, log, and configuration directories.
 VOLUME ["/data", "/var/log/postgresql", "/etc/postgresql"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Postgresql (http://www.postgresql.org/)
 
-FROM phusion/baseimage:0.9.13
+FROM phusion/baseimage:0.9.16
 MAINTAINER Ryan Seto <ryanseto@yak.net>
 
 # Ensure we create the cluster with UTF-8 locale
@@ -8,7 +8,9 @@ RUN locale-gen en_US.UTF-8 && \
     echo 'LANG="en_US.UTF-8"' > /etc/default/locale
 
 # Disable SSH (Not using it at the moment).
-RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
+#RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
+
+RUN /etc/my_init.d/00_regen_ssh_host_keys.sh
 
 # Install the latest postgresql
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
@@ -17,6 +19,11 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" > /etc/
     apt-get install -y --force-yes \
         postgresql-9.3 postgresql-client-9.3 postgresql-contrib-9.3 && \
     /etc/init.d/postgresql stop
+
+# work around for AUFS bug
+# as per https://github.com/docker/docker/issues/783#issuecomment-56013588
+RUN mkdir /etc/ssl/private-copy; mv /etc/ssl/private/* /etc/ssl/private-copy/; rm -r /etc/ssl/private; mv /etc/ssl/private-copy /etc/ssl/private; chmod -R 0700 /etc/ssl/private; chown -R postgres /etc/ssl/private
+
 
 # Install other tools.
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y pwgen inotify-tools

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ mkdir -p /tmp/postgresql
 $ docker run -d --name="postgresql" \
              -p 127.0.0.1:5432:5432 \
              -v /tmp/postgresql:/data \
-             -e USER="super" \
+             -e DB_USER="super" \
              -e DB="database_name" \
              -e PASS="$(pwgen -s -1 16)" \
              paintedfox/postgresql
@@ -68,7 +68,7 @@ directory, and the superuser username and password on the host like so:
 $ sudo mkdir -p /srv/docker/postgresql
 $ make run PORT=127.0.0.1:5432 \
            DATA_DIR=/srv/docker/postgresql \
-           USER=super \
+           DB_USER=super \
            PASS=$(pwgen -s -1 16)
 ```
 
@@ -88,7 +88,7 @@ password for the superuser.  To view the login in run `docker logs
 
 ``` shell
 $ docker logs postgresql
-POSTGRES_USER=super
+POSTGRES_DB_USER=super
 POSTGRES_PASS=b2rXEpToTRoK8PBx
 POSTGRES_DATA_DIR=/data
 Starting PostgreSQL...
@@ -136,7 +136,7 @@ $ psql -U "$DB_ENV_USER" \
        -p "$DB_PORT_5432_TCP_PORT"
 ```
 
-If you ran the *postgresql* container with the flags `-e USER=<user>` and `-e
+If you ran the *postgresql* container with the flags `-e DB_USER=<user>` and `-e
 PASS=<pass>`, then the linked container should have these variables available
 in its environment.  Since we aliased the database container with the name
 *db*, the environment variables from the database container are copied into the

--- a/scripts/first_run.sh
+++ b/scripts/first_run.sh
@@ -13,7 +13,7 @@ pre_start_action() {
       echo "Initializing PostgreSQL at $DATA_DIR"
 
       # Copy the data that we generated within the container to the empty DATA_DIR.
-      cp -R /var/lib/postgresql/9.3/main/* $DATA_DIR
+      cp -aR /var/lib/postgresql/9.3/main/* $DATA_DIR
   fi
 
   # Ensure postgres owns the DATA_DIR

--- a/scripts/first_run.sh
+++ b/scripts/first_run.sh
@@ -1,4 +1,4 @@
-USER=${USER:-super}
+USER=${DB_USER:-super}
 PASS=${PASS:-$(pwgen -s -1 16)}
 
 pre_start_action() {


### PR DESCRIPTION
Fix Autovacum start in postgres.
The logs (docker logs postgresql) show the error: LOG:  could not open temporary statistics file "/var/run/postgresql/9.3-main.pg_stat_tmp/global.tmp"
And autovacum does not start

I suggest to create a releases/v9.3 branch to maintain
